### PR TITLE
Stop logging search pairs to console

### DIFF
--- a/IDCAC-original/data/js/common.js
+++ b/IDCAC-original/data/js/common.js
@@ -500,7 +500,7 @@
 			document.querySelectorAll(searchPairsJoinedKeys).forEach(function(box) {
 				searchPairsKeys.forEach(function(selector) {
 					if (box.matches(selector)) {
-						console.log(searchPairs[selector].join(','));
+						//console.log(searchPairs[selector].join(','));
 						(box.shadowRoot || box).querySelectorAll(searchPairs[selector].join(',')).forEach(function(button) {
 							if (button.click && !button.classList.contains('idcac')) {
 								button.classList.add('idcac');


### PR DESCRIPTION
This comments out the console.log debug function, making debugging other website easier when there is less noise in the browser console due to a noisy extension